### PR TITLE
Add configurable update time for Docker version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,10 @@ RUN if [ "$INSTALL_CHROMIUM" = "true" ]; then \
 
 RUN  apt-get clean && rm -rf /var/lib/apt/lists/*
 
+ARG UPDATE_CRON="0 22 * * *"
+
 RUN (crontab -l ; \
-  echo "0 22 * * * cd $APP_WORKDIR && /usr/local/bin/pipenv run python main.py scheduled_task"; \
+  echo "$UPDATE_CRON cd $APP_WORKDIR && /usr/local/bin/pipenv run python main.py scheduled_task"; \
   echo "0 10 * * * cd $APP_WORKDIR && /usr/local/bin/pipenv run python main.py scheduled_task") | crontab -
 
 EXPOSE 8000

--- a/config/config.ini
+++ b/config/config.ini
@@ -45,3 +45,4 @@ multicast_num = 10
 subscribe_num = 10
 online_search_num = 0
 open_url_info = True
+update_cron = 0 6,18 * * *

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -226,3 +226,27 @@ docker run -d -p 8000:8000 guovern/tv-requests 或 tv-driver
 如果您没有自己的域名地址，接口更新完成后，将 user_result.txt 上传至个人仓库，即可使用
 https://mirror.ghproxy.com/raw.githubusercontent.com/您的github用户名/仓库名称（对应上述Fork创建时的TV）/master/output/user_result.txt
 ![用户名与仓库名称](./images/rep-info.png '用户名与仓库名称')
+
+### 配置 Docker 版本的定时更新
+
+Docker 版本现在支持配置定时更新的时间或间隔。您可以通过设置 `UPDATE_CRON` 环境变量来自定义 cron 调度。
+
+#### 1. 设置 `UPDATE_CRON` 环境变量
+
+在运行 Docker 容器时，您可以通过 `-e` 参数设置 `UPDATE_CRON` 环境变量。例如：
+
+```bash
+docker run -d -p 8000:8000 -e UPDATE_CRON="0 6,18 * * *" guovern/tv-requests
+```
+
+上述命令将会在每天的 6:00 和 18:00 进行更新。您可以根据需要修改 `UPDATE_CRON` 的值来设置不同的更新频率。
+
+#### 2. 修改 `config/config.ini` 文件
+
+您还可以在 `config/config.ini` 文件中设置 `update_cron` 参数来指定 cron 调度。例如：
+
+```ini
+update_cron = 0 6,18 * * *
+```
+
+上述配置将会在每天的 6:00 和 18:00 进行更新。您可以根据需要修改 `update_cron` 的值来设置不同的更新频率。

--- a/docs/tutorial_en.md
+++ b/docs/tutorial_en.md
@@ -223,3 +223,27 @@ result:
 If you do not have your own domain address, after the interface update is completed, upload user_result.txt to your personal repository to use it.
 https://mirror.ghproxy.com/raw.githubusercontent.com/your github username/repository name (corresponding to the TV created when forking)/master/output/user_result.txt
 ![Username and Repository Name](./images/rep-info.png 'Username and Repository Name')
+
+### Configure Scheduled Updates for Docker Version
+
+The Docker version now supports configuring the update time or interval. You can customize the cron schedule by setting the `UPDATE_CRON` environment variable.
+
+#### 1. Set the `UPDATE_CRON` environment variable
+
+When running the Docker container, you can set the `UPDATE_CRON` environment variable using the `-e` parameter. For example:
+
+```bash
+docker run -d -p 8000:8000 -e UPDATE_CRON="0 6,18 * * *" guovern/tv-requests
+```
+
+The above command will update at 6:00 AM and 6:00 PM every day. You can modify the value of `UPDATE_CRON` as needed to set different update frequencies.
+
+#### 2. Modify the `config/config.ini` file
+
+You can also set the `update_cron` parameter in the `config/config.ini` file to specify the cron schedule. For example:
+
+```ini
+update_cron = 0 6,18 * * *
+```
+
+The above configuration will update at 6:00 AM and 6:00 PM every day. You can modify the value of `update_cron` as needed to set different update frequencies.


### PR DESCRIPTION
Fixes #440

Add configuration for scheduled updates in Docker version.

* **Dockerfile**
  - Add `UPDATE_CRON` environment variable to allow custom cron schedules.
  - Modify the `RUN` command to use the `UPDATE_CRON` variable for setting the cron jobs.

* **config/config.ini**
  - Add a new setting `update_cron` for specifying the cron schedule.

* **docs/tutorial.md**
  - Update the documentation to explain how to configure the update time or interval for the Docker version.

* **docs/tutorial_en.md**
  - Update the documentation to explain how to configure the update time or interval for the Docker version.

