### PR TITLE
Release: v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - 🐛 修复无结果状态文件写入报错（#841）
 - 🐛 修复GUI无法保存测速延迟设置
 - 🐛 修复Docker版本文件丢失（#800）
+- 🪄 `open_use_old_result`更名为`open_history`
 - 🪄 优化对接口中`%`符号的转义处理（#853）
 - 🪄 优化以接口Host去重（#846）
 - 🪄 支持协议类型偏好`ipv_type_prefer`可设置为空，可实现全部类型按速率排序输出结果
@@ -31,6 +32,7 @@
 - 🐛 Fixed error writing to file in no result state (#841)
 - 🐛 Fixed GUI unable to save speed test delay settings
 - 🐛 Fixed Docker version file loss issue (#800)
+- 🪄 `open_use_old_result` renamed to `open_history`
 - 🪄 Optimized escaping of `%` symbol in interfaces (#853)
 - 🪄 Optimized deduplication by interface host (#846)
 - 🪄 Supported setting `ipv_type_prefer` to empty, allowing all types to be sorted by speed for output results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # 更新日志（Changelog）
 
+## v1.6.0
+
+### 2025/1/22
+
+- ✨ 新增支持`本地源`
+- ✨ 使用新的代理地址`https://ghproxy.cc`
+- ✨ 新增支持Docker修改定时任务时间，环境变量：`UPDATE_CRON1`, `UPDATE_CRON2`（#440）
+- ✨ 新增同域名重复执行测速次数配置`sort_duplicate_limit`
+- ✨ 新增`广东联通`RTP
+- 🐛 修复补偿模式结果输出问题（#813）
+- 🐛 修复无域名后缀、空格接口匹配问题（#832，#837）
+- 🐛 修复无结果状态文件写入报错（#841）
+- 🐛 修复GUI无法保存测速延迟设置
+- 🐛 修复Docker版本文件丢失（#800）
+- 🪄 优化对接口中`%`符号的转义处理（#853）
+- 🪄 优化以接口Host去重（#846）
+- 🪄 支持协议类型偏好`ipv_type_prefer`可设置为空，可实现全部类型按速率排序输出结果
+
+<details>
+  <summary>English</summary>
+
+- ✨ Added support for `local sources`
+- ✨ Using new proxy address `https://ghproxy.cc`
+- ✨ Added support for modifying Docker scheduled task time, environment variables: `UPDATE_CRON1`, `UPDATE_CRON2` (#440)
+- ✨ Added configuration for the number of speed tests for the same domain `sort_duplicate_limit`
+- ✨ Added `Guangdong Unicom` RTP
+- 🐛 Fixed compensation mode result output issue (#813)
+- 🐛 Fixed issue with interface matching without domain suffix and spaces (#832, #837)
+- 🐛 Fixed error writing to file in no result state (#841)
+- 🐛 Fixed GUI unable to save speed test delay settings
+- 🐛 Fixed Docker version file loss issue (#800)
+- 🪄 Optimized escaping of `%` symbol in interfaces (#853)
+- 🪄 Optimized deduplication by interface host (#846)
+- 🪄 Supported setting `ipv_type_prefer` to empty, allowing all types to be sorted by speed for output results
+
+</details>
+
 ## v1.5.9
 
 ### 2025/1/8

--- a/tkinter_ui/prefer.py
+++ b/tkinter_ui/prefer.py
@@ -32,13 +32,12 @@ class PreferUI:
         self.prefer_ipv_type_combo = ttk.Combobox(frame_prefer_ipv_type)
         self.prefer_ipv_type_combo.pack(side=tk.LEFT, padx=4, pady=8)
         self.prefer_ipv_type_combo["values"] = ("IPv4", "IPv6", "自动")
-        ipv_type_prefer = config.ipv_type_prefer[0]
-        if ipv_type_prefer == "ipv4":
-            self.prefer_ipv_type_combo.current(0)
-        elif ipv_type_prefer == "ipv6":
-            self.prefer_ipv_type_combo.current(1)
-        elif ipv_type_prefer in ["自动", "auto"]:
-            self.prefer_ipv_type_combo.current(2)
+        ipv_type_prefer = config.ipv_type_prefer
+        if ipv_type_prefer:
+            first_ipv_type_prefer = ipv_type_prefer[0]
+            prefer_map = {"ipv4": 0, "ipv6": 1, "自动": 2, "auto": 2}
+            if first_ipv_type_prefer in prefer_map:
+                self.prefer_ipv_type_combo.current(prefer_map[first_ipv_type_prefer])
         self.prefer_ipv_type_combo.bind(
             "<<ComboboxSelected>>", self.update_ipv_type_prefer
         )

--- a/utils/channel.py
+++ b/utils/channel.py
@@ -68,10 +68,11 @@ def get_channel_data_from_file(channels, file, whitelist, open_local=config.open
                 if name in whitelist:
                     for whitelist_url in whitelist[name]:
                         category_dict[name].append((whitelist_url, None, None, "whitelist"))
-                if open_local and url:
-                    data = format_channel_data(url, "local")
-                    if data not in category_dict[name]:
-                        category_dict[name].append(data)
+                if open_local:
+                    if url:
+                        data = format_channel_data(url, "local")
+                        if data not in category_dict[name]:
+                            category_dict[name].append(data)
                     if local_data and name in local_data:
                         for local_url in local_data[name]:
                             local_channel_data = format_channel_data(local_url, "local")

--- a/utils/config.py
+++ b/utils/config.py
@@ -93,15 +93,17 @@ class ConfigManager:
 
     @property
     def ipv4_num(self):
-        return self.config.getint("Settings", "ipv4_num", fallback=5) if self.config.get(
-            "Settings", "ipv_type_prefer", fallback=""
-        ) else ""
+        try:
+            return self.config.getint("Settings", "ipv4_num", fallback=5)
+        except:
+            return ""
 
     @property
     def ipv6_num(self):
-        return self.config.getint("Settings", "ipv6_num", fallback=5) if self.config.get(
-            "Settings", "ipv_type_prefer", fallback=""
-        ) else ""
+        try:
+            return self.config.getint("Settings", "ipv6_num", fallback=5)
+        except:
+            return ""
 
     @property
     def ipv6_support(self):

--- a/utils/speed.py
+++ b/utils/speed.py
@@ -90,7 +90,7 @@ async def get_speed_m3u8(url: str, filter_resolution: bool = config.open_filter_
     info = {'speed': None, 'delay': None, 'resolution': None}
     location = None
     try:
-        url = quote(url, safe=':/?$&=@[]').partition('$')[0]
+        url = quote(url, safe=':/?$&=@[]%').partition('$')[0]
         async with ClientSession(connector=TCPConnector(ssl=False), trust_env=True) as session:
             headers = await get_m3u8_headers(url, session)
             location = headers.get('Location')

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.5.9",
+  "version": "1.6.0",
   "name": "IPTV-API"
 }


### PR DESCRIPTION
<!--
注意！这是修复代码或添加新功能的 Pull Request，请仔细确认合并的目标仓库名称。
不要提交无效的PR（包括个人配置或更新结果的变更），否则将会被直接关闭，严重将会被列入黑名单！
Attention! This is a Pull Request to fix code or add new functionality. Please carefully confirm the target repository name for the merge.
Do not submit invalid PR (including personal configuration or result changes), otherwise it will be directly closed, serious will be blacklisted!
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Release
- [ ] Other, please describe:

**Which environment is this PR for?** (check at least one)

- [x] Workflow
- [x] GUI
- [x] Docker
- [x] Command line
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [x] Yes
- [ ] No

If yes, please describe the impact and migration path for existing applications:

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue
  first and wait for approval before working on it)

**Other information:**
- ✨ 新增支持`本地源`
- ✨ 使用新的代理地址`https://ghproxy.cc`
- ✨ 新增支持Docker修改定时任务时间，环境变量：`UPDATE_CRON1`, `UPDATE_CRON2`（#440）
- ✨ 新增同域名重复执行测速次数配置`sort_duplicate_limit`
- ✨ 新增`广东联通`RTP
- 🐛 修复补偿模式结果输出问题（#813）
- 🐛 修复无域名后缀、空格接口匹配问题（#832，#837）
- 🐛 修复无结果状态文件写入报错（#841）
- 🐛 修复GUI无法保存测速延迟设置
- 🐛 修复Docker版本文件丢失（#800）
- 🪄 `open_use_old_result`更名为`open_history`
- 🪄 优化对接口中`%`符号的转义处理（#853）
- 🪄 优化以接口Host去重（#846）
- 🪄 支持协议类型偏好`ipv_type_prefer`可设置为空，可实现全部类型按速率排序输出结果

<details>
  <summary>English</summary>

- ✨ Added support for `local sources`
- ✨ Using new proxy address `https://ghproxy.cc`
- ✨ Added support for modifying Docker scheduled task time, environment variables: `UPDATE_CRON1`, `UPDATE_CRON2` (#440)
- ✨ Added configuration for the number of speed tests for the same domain `sort_duplicate_limit`
- ✨ Added `Guangdong Unicom` RTP
- 🐛 Fixed compensation mode result output issue (#813)
- 🐛 Fixed issue with interface matching without domain suffix and spaces (#832, #837)
- 🐛 Fixed error writing to file in no result state (#841)
- 🐛 Fixed GUI unable to save speed test delay settings
- 🐛 Fixed Docker version file loss issue (#800)
- 🪄 `open_use_old_result` renamed to `open_history`
- 🪄 Optimized escaping of `%` symbol in interfaces (#853)
- 🪄 Optimized deduplication by interface host (#846)
- 🪄 Supported setting `ipv_type_prefer` to empty, allowing all types to be sorted by speed for output results

</details>