### PR TITLE
feat: support proxy for session.get and requests.get and driver mode

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -123,3 +123,7 @@ urls_limit = 10
 update_interval = 12
 # 更新时间显示位置，需要开启 open_update_time 才能生效，可选值：top、bottom，top: 显示于结果顶部，bottom: 显示于结果底部 | Update time display position, need to enable open_update_time to take effect, optional values: top, bottom, top: display at the top of the result, bottom: display at the bottom of the result
 update_time_position = top
+# 访问 subscribe 中 github 等地址下载列表时使用的 http 代理，当 https 代理不存在时，https 代理也使用 http 代理 | he HTTP proxy used to access the download list from GitHub and other addresses in the subscribe, when the HTTPS proxy does not exist, the HTTPS proxy also uses the HTTP proxy
+http_proxy =
+# 访问 subscribe 中 github 等地址下载列表时使用的 https 代理 | The HTTPS proxy used to access the download list from GitHub and other addresses in the subscribe
+https_proxy =

--- a/main.py
+++ b/main.py
@@ -83,7 +83,7 @@ class UpdateSource:
                     subscribe_urls = get_urls_from_file(constants.subscribe_path)
                     whitelist_urls = get_urls_from_file(constants.whitelist_path)
                     if not os.getenv("GITHUB_ACTIONS") and config.cdn_url:
-                        subscribe_urls = [join_url(config.cdn_url, url) if "raw.githubusercontent.com" in url else url
+                        subscribe_urls = [join_url(config.cdn_url, url) if "raw.githubusercontent.com" in url and not config.have_local_proxy else url
                                           for url in subscribe_urls]
                     task = asyncio.create_task(
                         task_func(subscribe_urls,

--- a/tkinter_ui/default.py
+++ b/tkinter_ui/default.py
@@ -461,6 +461,29 @@ class DefaultUI:
         )
         self.rtmp_stat_button.pack(side=tk.LEFT, padx=4, pady=0)
 
+        frame_time_zone1 = tk.Frame(root)
+        frame_time_zone1.pack(fill=tk.X)
+        frame_time_zone_column3 = tk.Frame(
+            frame_time_zone1
+        )
+        frame_time_zone_column3.pack(side=tk.RIGHT, fill=tk.Y)
+
+        self.local_proxy_label = tk.Label(
+            frame_time_zone_column3, text="本地代理:", width=12
+        )
+        self.local_proxy_label.pack(side=tk.LEFT, padx=4, pady=8)
+        self.local_proxy_entry = tk.Entry(frame_time_zone_column3, width=20)
+        self.local_proxy_entry.pack(side=tk.LEFT, padx=4, pady=8)
+        self.local_proxy_entry.insert(0, config.http_proxy)
+        self.local_proxy_entry.bind("<KeyRelease>", self.update_local_proxy)
+
+        frame_default_url_keywords = tk.Frame(root)
+        frame_default_url_keywords.pack(fill=tk.X)
+        frame_default_url_keywords_column1 = tk.Frame(frame_default_url_keywords)
+        frame_default_url_keywords_column1.pack(side=tk.LEFT, fill=tk.Y)
+        frame_default_url_keywords_column2 = tk.Frame(frame_default_url_keywords)
+        frame_default_url_keywords_column2.pack(side=tk.RIGHT, fill=tk.Y)
+
     def update_open_update(self):
         config.set("Settings", "open_update", str(self.open_update_var.get()))
 
@@ -528,6 +551,9 @@ class DefaultUI:
     def update_cdn_url(self, event):
         config.set("Settings", "cdn_url", self.cdn_url_entry.get())
 
+    def update_local_proxy(self, event):
+        config.set("Settings", "http_proxy", self.local_proxy_entry.get())
+
     def update_open_update_time(self):
         config.set("Settings", "open_update_time", str(self.open_update_time_var.get()))
 
@@ -587,6 +613,7 @@ class DefaultUI:
             "source_file_edit_button",
             "time_zone_entry",
             "cdn_url_entry",
+            "local_proxy_entry",
             "final_file_entry",
             "final_file_button",
             "final_file_edit_button",

--- a/updates/fofa/request.py
+++ b/updates/fofa/request.py
@@ -12,7 +12,7 @@ import updates.fofa.fofa_map as fofa_map
 import utils.constants as constants
 from utils.channel import format_channel_name
 from utils.config import config
-from utils.requests.tools import get_source_requests, close_session
+from utils.requests.tools import get_source_requests, close_session, get_local_proxy
 from utils.retry import retry_func
 from utils.tools import merge_objects, get_pbar_remaining, resource_path
 
@@ -196,7 +196,7 @@ def process_fofa_json_url(url, region, open_speed_test, hotel_name="酒店源"):
         #     lambda: get(final_url, timeout=timeout),
         #     name=final_url,
         # )
-        response = get(final_url, timeout=config.request_timeout)
+        response = get(final_url, proxies=get_local_proxy(), timeout=config.request_timeout)
         try:
             json_data = response.json()
             if json_data["code"] == 0:

--- a/updates/multicast/update_tmp.py
+++ b/updates/multicast/update_tmp.py
@@ -9,6 +9,7 @@ from utils.config import config
 import utils.constants as constants
 from utils.channel import format_channel_name
 from utils.tools import get_pbar_remaining, resource_path, get_name_url
+from utils.requests.tools import get_local_proxy
 import json
 
 # import asyncio
@@ -88,7 +89,7 @@ def get_multicast_region_type_result_txt():
         session = Session()
         for region, value in region_url.items():
             for type, url in value.items():
-                response = session.get(url)
+                response = session.get(url, proxies=get_local_proxy())
                 content = response.text
                 with open(
                         resource_path(f"config/rtp/{region}_{type}.txt"),

--- a/updates/subscribe/request.py
+++ b/updates/subscribe/request.py
@@ -14,6 +14,7 @@ from utils.tools import (
     get_pbar_remaining,
     get_name_url
 )
+from utils.requests.tools import get_local_proxy
 
 
 async def get_channels_by_subscribe_urls(
@@ -58,6 +59,8 @@ async def get_channels_by_subscribe_urls(
         channels = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
         in_whitelist = whitelist and (subscribe_url in whitelist)
         session = Session()
+        if config.have_local_proxy:
+            session.proxies = get_local_proxy()
         try:
             response = None
             try:

--- a/utils/config.py
+++ b/utils/config.py
@@ -316,6 +316,18 @@ class ConfigManager:
         return os.getenv("APP_HOST") or self.config.get("Settings", "app_host", fallback="http://localhost")
 
     @property
+    def http_proxy(self):
+        return self.config.get("Settings", "http_proxy", fallback=None)
+
+    @property
+    def https_proxy(self):
+        return self.config.get("Settings", "https_proxy", fallback=None)
+
+    @property
+    def have_local_proxy(self):
+        return True if self.http_proxy or self.https_proxy else False
+
+    @property
     def app_port(self):
         return os.getenv("APP_PORT") or self.config.getint("Settings", "app_port", fallback=8000)
 

--- a/utils/driver/setup.py
+++ b/utils/driver/setup.py
@@ -11,6 +11,11 @@ def setup_driver(proxy=None):
     """
     Setup the driver for selenium
     """
+    if config.https_proxy:
+        proxy = config.https_proxy
+    elif config.http_proxy:
+        proxy = config.http_proxy
+
     options = webdriver.ChromeOptions()
     options.add_argument("start-maximized")
     options.add_argument("--headless")

--- a/utils/requests/tools.py
+++ b/utils/requests/tools.py
@@ -2,6 +2,7 @@ import re
 
 import requests
 from bs4 import BeautifulSoup
+from utils.config import config
 
 headers = {
     "Accept": "*/*",
@@ -17,13 +18,15 @@ def get_source_requests(url, data=None, proxy=None, timeout=30):
     """
     Get the source by requests
     """
-    proxies = {"http": proxy}
+
+    if (proxy == None and config.have_local_proxy):
+        proxy = get_local_proxy()
     if data:
         response = session.post(
-            url, headers=headers, data=data, proxies=proxies, timeout=timeout
+            url, headers=headers, data=data, proxies=proxy, timeout=timeout
         )
     else:
-        response = session.get(url, headers=headers, proxies=proxies, timeout=timeout)
+        response = session.get(url, headers=headers, proxies=proxy, timeout=timeout)
     source = re.sub(
         r"<!--.*?-->",
         "",
@@ -41,6 +44,30 @@ def get_soup_requests(url, data=None, proxy=None, timeout=30):
     soup = BeautifulSoup(source, "html.parser")
     return soup
 
+def get_local_proxy():
+    """
+    Get the peoxy from config.ini
+    """
+    open_driver = config.open_driver
+
+    http_proxy = config.http_proxy
+    https_proxy = config.https_proxy
+
+    proxies = {}
+
+    if http_proxy and https_proxy:
+            proxies['http'] = http_proxy
+            proxies['https'] = https_proxy
+    elif http_proxy:
+            proxies['http'] = http_proxy
+            proxies['https'] = http_proxy
+    elif https_proxy:
+            proxies['http'] = https_proxy
+            proxies['https'] = https_proxy
+    else:
+        return None
+
+    return proxies
 
 def close_session():
     """

--- a/utils/speed.py
+++ b/utils/speed.py
@@ -15,6 +15,7 @@ import utils.constants as constants
 from utils.config import config
 from utils.tools import get_resolution_value, get_logger
 from utils.types import TestResult, ChannelTestResult, TestResultCacheData
+from utils.requests.tools import get_local_proxy
 
 http.cookies._is_legal_key = lambda _: True
 cache: TestResultCacheData = {}
@@ -108,7 +109,7 @@ async def get_url_content(url: str, headers: dict = None, session: ClientSession
         created_session = False
     content = ""
     try:
-        async with session.get(url, headers=headers, timeout=timeout) as response:
+        async with session.get(url, headers=headers, proxies=get_local_proxy(), timeout=timeout) as response:
             if response.status == 200:
                 content = await response.text()
             else:

--- a/utils/tools.py
+++ b/utils/tools.py
@@ -337,7 +337,8 @@ def get_epg_url():
     if os.getenv("GITHUB_ACTIONS"):
         repository = os.getenv("GITHUB_REPOSITORY", "Guovin/iptv-api")
         ref = os.getenv("GITHUB_REF", "gd")
-        return join_url(config.cdn_url, f"https://raw.githubusercontent.com/{repository}/{ref}/output/epg/epg.gz")
+        url = f"https://raw.githubusercontent.com/{repository}/{ref}/output/epg/epg.gz"
+        return join_url(config.cdn_url, url) if not config.have_local_proxy else url
     else:
         return f"{get_ip_address()}/epg/epg.gz"
 
@@ -368,7 +369,9 @@ def convert_to_m3u(path=None, first_channel_name=None, data=None):
                                       + ("+" if m.group(3) else ""),
                             first_channel_name if current_group == "🕘️更新时间" else original_channel_name,
                         )
-                        m3u_output += f'#EXTINF:-1 tvg-name="{processed_channel_name}" tvg-logo="{join_url(config.cdn_url, f'https://raw.githubusercontent.com/fanmingming/live/main/tv/{processed_channel_name}.png')}"'
+                        tv_logo_url =f'https://raw.githubusercontent.com/fanmingming/live/main/tv/{processed_channel_name}.png'
+                        url = join_url(config.cdn_url, tv_logo_url) if not config.have_local_proxy else tv_logo_url
+                        m3u_output += f'#EXTINF:-1 tvg-name="{processed_channel_name}" tvg-logo="{url}"'
                         if current_group:
                             m3u_output += f' group-title="{current_group}"'
                         item_data = {}


### PR DESCRIPTION
<!--
！！！⚠️ 警告⚠️ ！！！更新代码不要使用该功能！！！请参考：https://github.com/Guovin/iptv-api/blob/master/docs/tutorial.md
这是修复代码或添加新功能的PR，在点击下方绿色按钮创建PR之前，请再次确认上面要合并的目标仓库（箭头指向的仓库名称）。
如果你只是想操作修改自己的仓库代码，箭头指向的base repository一定不能是Guovin/iptv-api！这会将你的代码提交合并到主仓库，导致产生无效PR以及垃圾邮件！
勿提交无效的PR（包括个人配置或更新结果），如果你是小白或非开发人员，最好不要使用该功能。
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Release
- [ ] Other, please describe:

**Which environment is this PR for?** (check at least one)

- [ ] Workflow
- [x] GUI
- [x] Docker
- [x] Command line
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

部分环境下 github 等前置代理存在失效的情况，大多数人都有本地代理，可能为 socks，也可以转换为 http 代理，python 中 requests 库和相应的 session 方法都支持加入代理参数，修改内部 session.get 和 requests.get driver 模式支持添加 http/https 代理
根据之前的修改建议，调整了相应修改
1. proxy 代理使用全局函数获取代理结构
2. https 优先使用 https_proxy ,若不存在 https_proxy 则使用 http_proxy
3. driver 模式在 setup_driver 函数内添加了代理支持
4. cdn_url 和 proxy 同时存在时，优先使用 proxy
5. m3u 结果资源图标文件是 github 路径，这个如果有代理则不添加前置 cdn_url
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue
  first and wait for approval before working on it)

**Other information:**