### PR TITLE
Pull Request: Optimize process_nested_dict and Data Copying Strategy

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,4 @@
 import asyncio
-import copy
 import datetime
 import gzip
 import os
@@ -246,20 +245,23 @@ class UpdateSource:
         """
         Run speed test on the channel data and return the test results.
         """
-        test_data = {
-            category: copy.deepcopy(items)
-            for category, items in self.channel_data.items()
-            if category != t("content.unmatch_channel")
-        }
+        # Use a shallow two-level copy instead of deepcopy:
+        # process_nested_dict replaces entire lists (not mutating individual items),
+        # so we only need to copy the list wrappers, not each dict inside them.
+        test_data = {}
+        for category, items in self.channel_data.items():
+            if category == t("content.unmatch_channel"):
+                continue
+            test_data[category] = {name: list(url_list) for name, url_list in items.items()}
+
         urls_total = get_urls_len(test_data)
 
-        process_nested_dict(
+        self.total = process_nested_dict(
             test_data,
             seen=set(),
             filter_host=config.speed_test_filter_host,
             ipv6_support=self.ipv6_support,
         )
-        self.total = get_urls_len(test_data)
 
         print(t("msg.total_urls_need_test_speed").format(total=urls_total, speed_total=self.total))
 

--- a/utils/tools.py
+++ b/utils/tools.py
@@ -568,13 +568,17 @@ def remove_duplicates_from_list(data_list, seen, filter_host=False, ipv6_support
 
 def process_nested_dict(data, seen, filter_host=False, ipv6_support=True):
     """
-    Process nested dict
+    Process nested dict in-place, removing duplicate URLs from lists.
+    Returns the total number of remaining URLs after deduplication.
     """
+    total = 0
     for key, value in data.items():
         if isinstance(value, dict):
-            process_nested_dict(value, seen, filter_host, ipv6_support)
+            total += process_nested_dict(value, seen, filter_host, ipv6_support)
         elif isinstance(value, list):
             data[key] = remove_duplicates_from_list(value, seen, filter_host, ipv6_support)
+            total += len(data[key])
+    return total
 
 
 def get_url_host(url):


### PR DESCRIPTION
Overview
This PR improves the performance of URL deduplication and statistics in process_nested_dict and replaces heavy deepcopy with a lightweight shallow-copy approach, reducing unnecessary traversals and memory overhead.

Changes
1. tools.py — Merge counting into process_nested_dict
Before: The function performed deduplication and updated the dictionary, then separately called get_urls_len to traverse the entire data structure again to count the remaining URLs.

After: While iterating for deduplication, the function now accumulates the count of actually kept URLs and returns this total as an additional return value.

Benefit: Eliminates one full traversal, saving O(N) time—especially significant for large datasets.

2. main.py — Replace deepcopy with lightweight shallow copy
Before: copy.deepcopy was used to fully clone the nested dictionary, which is expensive.

After: Since process_nested_dict only replaces entire lists (data[key] = new_list) and never modifies inner dict objects, we now use a two‑level shallow copy to ensure isolation.

Removed: The unused import copy statement is deleted.

Benefit: Drastically reduces copying cost, lowering memory peak usage.